### PR TITLE
[8.x] Pass the full custom pivot model to the delete & deleting events.

### DIFF
--- a/CHANGELOG-8.x.md
+++ b/CHANGELOG-8.x.md
@@ -1,6 +1,15 @@
 # Release Notes for 8.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v8.83.14...8.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v8.83.15...8.x)
+
+
+## [v8.83.14 (2022-05-31)](https://github.com/laravel/framework/compare/v8.83.14...v8.83.15)
+
+### Reverted
+- Revert digits changes in Validator ([c6d1a2d](https://github.com/laravel/framework/commit/c6d1a2da17e3aaaeb0ff5b8cc4879816d214b527), [#42562](https://github.com/laravel/framework/pull/42562))
+
+### Changed
+- Retain the original attribute value during validation of an array key with a dot for correct failure message ([#42395](https://github.com/laravel/framework/pull/42395))
 
 
 ## [v8.83.14 (2022-05-24)](https://github.com/laravel/framework/compare/v8.83.13...v8.83.14)

--- a/CHANGELOG-8.x.md
+++ b/CHANGELOG-8.x.md
@@ -1,6 +1,16 @@
 # Release Notes for 8.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v8.83.12...8.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v8.83.13...8.x)
+
+
+## [v8.83.13 (2022-05-17)](https://github.com/laravel/framework/compare/v8.83.12...v8.83.13)
+
+### Fixed
+- Fix PruneCommand finding its usage within other traits ([#42350](https://github.com/laravel/framework/pull/42350))
+
+### Changed
+- Consistency between digits and digits_between validation rules ([#42358](https://github.com/laravel/framework/pull/42358))
+- Corrects the use of "failed_jobs" instead of "job_batches" in BatchedTableCommand ([#42389](https://github.com/laravel/framework/pull/42389))
 
 
 ## [v8.83.12 (2022-05-10)](https://github.com/laravel/framework/compare/v8.83.11...v8.83.12)

--- a/CHANGELOG-8.x.md
+++ b/CHANGELOG-8.x.md
@@ -1,6 +1,15 @@
 # Release Notes for 8.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v8.83.13...8.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v8.83.14...8.x)
+
+
+## [v8.83.14 (2022-05-24)](https://github.com/laravel/framework/compare/v8.83.13...v8.83.14)
+
+### Fixed
+- Add flush handler to output buffer for streamed test response (bugfix) ([#42481](https://github.com/laravel/framework/pull/42481))
+
+### Changed
+- Use duplicate instead of createFromBase to clone request when routes are cached ([#42420](https://github.com/laravel/framework/pull/42420))
 
 
 ## [v8.83.13 (2022-05-17)](https://github.com/laravel/framework/compare/v8.83.12...v8.83.13)

--- a/CHANGELOG-8.x.md
+++ b/CHANGELOG-8.x.md
@@ -1,6 +1,16 @@
 # Release Notes for 8.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v8.83.11...8.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v8.83.12...8.x)
+
+
+## [v8.83.12 (2022-05-10)](https://github.com/laravel/framework/compare/v8.83.11...v8.83.12)
+
+### Fixed
+- Fixed multiple dots for digits_between rule ([#42330](https://github.com/laravel/framework/pull/42330))
+
+### Changed
+- Enable to modify HTTP Client request headers when using beforeSending() callback ([#42244](https://github.com/laravel/framework/pull/42244))
+- Set relation parent key when using forceCreate on HasOne and HasMany relations ([#42281](https://github.com/laravel/framework/pull/42281))
 
 
 ## [v8.83.11 (2022-05-03)](https://github.com/laravel/framework/compare/v8.83.10...v8.83.11)

--- a/CHANGELOG-8.x.md
+++ b/CHANGELOG-8.x.md
@@ -3,7 +3,7 @@
 ## [Unreleased](https://github.com/laravel/framework/compare/v8.83.15...8.x)
 
 
-## [v8.83.14 (2022-05-31)](https://github.com/laravel/framework/compare/v8.83.14...v8.83.15)
+## [v8.83.15 (2022-05-31)](https://github.com/laravel/framework/compare/v8.83.14...v8.83.15)
 
 ### Reverted
 - Revert digits changes in Validator ([c6d1a2d](https://github.com/laravel/framework/commit/c6d1a2da17e3aaaeb0ff5b8cc4879816d214b527), [#42562](https://github.com/laravel/framework/pull/42562))

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,7 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
+         printerClass="Illuminate\Tests\IgnoreSkippedPrinter"
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"

--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -87,7 +87,9 @@ class PruneCommand extends Command
     protected function models()
     {
         if (! empty($models = $this->option('model'))) {
-            return collect($models);
+            return collect($models)->filter(function ($model) {
+                return class_exists($model);
+            })->values();
         }
 
         $except = $this->option('except');
@@ -111,6 +113,8 @@ class PruneCommand extends Command
                 });
             })->filter(function ($model) {
                 return $this->isPrunable($model);
+            })->filter(function ($model) {
+                return class_exists($model);
             })->values();
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -475,7 +475,7 @@ trait InteractsWithPivotTable
 
         $pivots = $this->using::where($this->foreignPivotKey, $this->parent->{$this->parentKey})->whereIn($this->relatedPivotKey, $this->parseIds($ids))->get();
 
-        foreach($pivots as $pivot) {
+        foreach ($pivots as $pivot) {
             $results += $pivot->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey)->delete();
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -473,11 +473,10 @@ trait InteractsWithPivotTable
     {
         $results = 0;
 
-        foreach ($this->parseIds($ids) as $id) {
-            $results += $this->newPivot([
-                $this->foreignPivotKey => $this->parent->{$this->parentKey},
-                $this->relatedPivotKey => $id,
-            ], true)->delete();
+        $pivots = $this->using::where($this->foreignPivotKey, $this->parent->{$this->parentKey})->whereIn($this->relatedPivotKey, $this->parseIds($ids))->get();
+
+        foreach($pivots as $pivot) {
+            $results += $pivot->delete();
         }
 
         return $results;

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -476,7 +476,7 @@ trait InteractsWithPivotTable
         $pivots = $this->using::where($this->foreignPivotKey, $this->parent->{$this->parentKey})->whereIn($this->relatedPivotKey, $this->parseIds($ids))->get();
 
         foreach($pivots as $pivot) {
-            $results += $pivot->delete();
+            $results += $pivot->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey)->delete();
         }
 
         return $results;

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -298,6 +298,19 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
+     * Create a new instance of the related model. Allow mass-assignment.
+     *
+     * @param  array  $attributes
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function forceCreate(array $attributes = [])
+    {
+        $attributes[$this->getForeignKeyName()] = $this->getParentKey();
+
+        return $this->related->forceCreate($attributes);
+    }
+
+    /**
      * Create a Collection of new instances of the related model.
      *
      * @param  iterable  $records

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -33,7 +33,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @var string
      */
-    const VERSION = '8.83.13';
+    const VERSION = '8.83.14';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -33,7 +33,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @var string
      */
-    const VERSION = '8.83.14';
+    const VERSION = '8.83.15';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -33,7 +33,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @var string
      */
-    const VERSION = '8.83.11';
+    const VERSION = '8.83.12';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -33,7 +33,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @var string
      */
-    const VERSION = '8.83.12';
+    const VERSION = '8.83.13';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -36,7 +36,7 @@ class HandleExceptions
      */
     public function bootstrap(Application $app)
     {
-        self::$reservedMemory = str_repeat('x', 10240);
+        self::$reservedMemory = str_repeat('x', 32768);
 
         $this->app = $app;
 
@@ -203,6 +203,8 @@ class HandleExceptions
      */
     public function handleShutdown()
     {
+        self::$reservedMemory = null;
+
         if (! is_null($error = error_get_last()) && $this->isFatal($error['type'])) {
             $this->handleException($this->fatalErrorFromPhpError($error, 0));
         }
@@ -217,8 +219,6 @@ class HandleExceptions
      */
     protected function fatalErrorFromPhpError(array $error, $traceOffset = null)
     {
-        self::$reservedMemory = null;
-
         return new FatalError($error['message'], 0, $error, $traceOffset);
     }
 

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -159,9 +159,9 @@ class HandleExceptions
      */
     public function handleException(Throwable $e)
     {
-        try {
-            self::$reservedMemory = null;
+        self::$reservedMemory = null;
 
+        try {
             $this->getExceptionHandler()->report($e);
         } catch (Exception $e) {
             //
@@ -217,6 +217,8 @@ class HandleExceptions
      */
     protected function fatalErrorFromPhpError(array $error, $traceOffset = null)
     {
+        self::$reservedMemory = null;
+
         return new FatalError($error['message'], 0, $error, $traceOffset);
     }
 

--- a/src/Illuminate/Queue/Console/BatchesTableCommand.php
+++ b/src/Illuminate/Queue/Console/BatchesTableCommand.php
@@ -36,7 +36,7 @@ class BatchesTableCommand extends Command
     protected $composer;
 
     /**
-     * Create a new failed queue jobs table command instance.
+     * Create a new batched queue jobs table command instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @param  \Illuminate\Support\Composer  $composer
@@ -74,7 +74,7 @@ class BatchesTableCommand extends Command
      * @param  string  $table
      * @return string
      */
-    protected function createBaseMigration($table = 'failed_jobs')
+    protected function createBaseMigration($table = 'job_batches')
     {
         return $this->laravel['migration.creator']->create(
             'create_'.$table.'_table', $this->laravel->databasePath().'/migrations'
@@ -82,7 +82,7 @@ class BatchesTableCommand extends Command
     }
 
     /**
-     * Replace the generated migration with the failed job table stub.
+     * Replace the generated migration with the batches job table stub.
      *
      * @param  string  $path
      * @param  string  $table

--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -152,7 +152,7 @@ class CompiledRouteCollection extends AbstractRouteCollection
      */
     protected function requestWithoutTrailingSlash(Request $request)
     {
-        $trimmedRequest = Request::createFromBase($request);
+        $trimmedRequest = $request->duplicate();
 
         $parts = explode('?', $request->server->get('REQUEST_URI'), 2);
 

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -30,6 +30,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\RouteRegistrar prefix(string $prefix)
  * @method static \Illuminate\Routing\RouteRegistrar scopeBindings()
  * @method static \Illuminate\Routing\RouteRegistrar where(array $where)
+ * @method static \Illuminate\Routing\RouteRegistrar withoutMiddleware(array|string $middleware)
  * @method static \Illuminate\Routing\Router|\Illuminate\Routing\RouteRegistrar group(\Closure|string|array $attributes, \Closure|string $routes)
  * @method static \Illuminate\Routing\ResourceRegistrar resourceVerbs(array $verbs = [])
  * @method static string|null currentRouteAction()

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1491,11 +1491,17 @@ EOF;
             PHPUnit::fail('The response is not a streamed response.');
         }
 
-        ob_start();
+        ob_start(function (string $buffer): string {
+            $this->streamedContent .= $buffer;
+
+            return '';
+        });
 
         $this->sendContent();
 
-        return $this->streamedContent = ob_get_clean();
+        ob_end_clean();
+
+        return $this->streamedContent;
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -20,6 +20,10 @@ trait FormatsMessages
      */
     protected function getMessage($attribute, $rule)
     {
+        $attributeWithPlaceholders = $attribute;
+
+        $attribute = $this->replacePlaceholderInString($attribute);
+
         $inlineMessage = $this->getInlineMessage($attribute, $rule);
 
         // First we will retrieve the custom message for the validation rule if one
@@ -46,7 +50,7 @@ trait FormatsMessages
         // specific error message for the type of attribute being validated such
         // as a number, file or string which all have different message types.
         elseif (in_array($rule, $this->sizeRules)) {
-            return $this->getSizeMessage($attribute, $rule);
+            return $this->getSizeMessage($attributeWithPlaceholders, $rule);
         }
 
         // Finally, if no developer specified messages have been set, and no other

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -582,7 +582,7 @@ trait ValidatesAttributes
 
         $length = strlen((string) $value);
 
-        return ! preg_match('/[^0-9.]/', $value)
+        return ! preg_match('/[^0-9]/', $value)
                     && $length >= $parameters[0] && $length <= $parameters[1];
     }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -582,6 +582,15 @@ trait ValidatesAttributes
 
         $length = strlen((string) $value);
 
+        if (((string) $value) === '.') {
+            return false;
+        }
+
+        // Make sure there is not more than one dot...
+        if (($length - strlen(str_replace('.', '', (string) $value))) > 1) {
+            return false;
+        }
+
         return ! preg_match('/[^0-9.]/', $value)
                     && $length >= $parameters[0] && $length <= $parameters[1];
     }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -564,18 +564,7 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(1, $parameters, 'digits');
 
-        $length = strlen((string) $value);
-
-        if (((string) $value) === '.') {
-            return false;
-        }
-
-        // Make sure there is not more than one dot...
-        if (($length - strlen(str_replace('.', '', (string) $value))) > 1) {
-            return false;
-        }
-
-        return ! preg_match('/[^0-9.]/', $value)
+        return ! preg_match('/[^0-9]/', $value)
                     && strlen((string) $value) == $parameters[0];
     }
 
@@ -592,15 +581,6 @@ trait ValidatesAttributes
         $this->requireParameterCount(2, $parameters, 'digits_between');
 
         $length = strlen((string) $value);
-
-        if (((string) $value) === '.') {
-            return false;
-        }
-
-        // Make sure there is not more than one dot...
-        if (($length - strlen(str_replace('.', '', (string) $value))) > 1) {
-            return false;
-        }
 
         return ! preg_match('/[^0-9.]/', $value)
                     && $length >= $parameters[0] && $length <= $parameters[1];

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -564,7 +564,18 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(1, $parameters, 'digits');
 
-        return ! preg_match('/[^0-9]/', $value)
+        $length = strlen((string) $value);
+
+        if (((string) $value) === '.') {
+            return false;
+        }
+
+        // Make sure there is not more than one dot...
+        if (($length - strlen(str_replace('.', '', (string) $value))) > 1) {
+            return false;
+        }
+
+        return ! preg_match('/[^0-9.]/', $value)
                     && strlen((string) $value) == $parameters[0];
     }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -867,6 +867,8 @@ class Validator implements ValidatorContract
             $this->passes();
         }
 
+        $attributeWithPlaceholders = $attribute;
+
         $attribute = str_replace(
             [$this->dotPlaceholder, '__asterisk__'],
             ['.', '*'],
@@ -878,7 +880,7 @@ class Validator implements ValidatorContract
         }
 
         $this->messages->add($attribute, $this->makeReplacements(
-            $this->getMessage($attribute, $rule), $attribute, $rule, $parameters
+            $this->getMessage($attributeWithPlaceholders, $rule), $attribute, $rule, $parameters
         ));
 
         $this->failedRules[$attribute][$rule] = $parameters;

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -55,6 +55,15 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertEquals($created, $relation->create(['name' => 'taylor']));
     }
 
+    public function testForceCreateMethodProperlyCreatesNewModel()
+    {
+        $relation = $this->getRelation();
+        $created = $this->expectForceCreatedModel($relation, ['name' => 'taylor']);
+
+        $this->assertEquals($created, $relation->forceCreate(['name' => 'taylor']));
+        $this->assertEquals(1, $created->getAttribute('foreign_key'));
+    }
+
     public function testFindOrNewMethodFindsModel()
     {
         $relation = $this->getRelation();
@@ -301,6 +310,18 @@ class DatabaseEloquentHasManyTest extends TestCase
     {
         $model = $this->expectNewModel($relation, $attributes);
         $model->expects($this->once())->method('save');
+
+        return $model;
+    }
+
+    protected function expectForceCreatedModel($relation, $attributes)
+    {
+        $attributes[$relation->getForeignKeyName()] = $relation->getParentKey();
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->with($relation->getForeignKeyName())->andReturn($relation->getParentKey());
+
+        $relation->getRelated()->shouldReceive('forceCreate')->once()->with($attributes)->andReturn($model);
 
         return $model;
     }

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -129,6 +129,20 @@ class DatabaseEloquentHasOneTest extends TestCase
         $this->assertEquals($created, $relation->create(['name' => 'taylor']));
     }
 
+    public function testForceCreateMethodProperlyCreatesNewModel()
+    {
+        $relation = $this->getRelation();
+        $attributes = ['name' => 'taylor', $relation->getForeignKeyName() => $relation->getParentKey()];
+
+        $created = m::mock(Model::class);
+        $created->shouldReceive('getAttribute')->with($relation->getForeignKeyName())->andReturn($relation->getParentKey());
+
+        $relation->getRelated()->shouldReceive('forceCreate')->once()->with($attributes)->andReturn($created);
+
+        $this->assertEquals($created, $relation->forceCreate(['name' => 'taylor']));
+        $this->assertEquals(1, $created->getAttribute('foreign_key'));
+    }
+
     public function testRelationIsProperlyInitialized()
     {
         $relation = $this->getRelation();

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -92,6 +92,16 @@ No prunable [Illuminate\Tests\Database\NonPrunableTestModel] records found.
 EOF, str_replace("\r", '', $output->fetch()));
     }
 
+    public function testNonPrunableTestWithATrait()
+    {
+        $output = $this->artisan(['--model' => NonPrunableTrait::class]);
+
+        $this->assertEquals(<<<'EOF'
+No prunable models found.
+
+EOF, str_replace("\r", '', $output->fetch()));
+    }
+
     public function testTheCommandMayBePretended()
     {
         $db = new DB;
@@ -226,4 +236,9 @@ class PrunableTestModelWithoutPrunableRecords extends Model
 class NonPrunableTestModel extends Model
 {
     // ..
+}
+
+trait NonPrunableTrait
+{
+    use Prunable;
 }

--- a/tests/IgnoreSkippedPrinter.php
+++ b/tests/IgnoreSkippedPrinter.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Tests;
+
+use PHPUnit\Framework\TestResult;
+use PHPUnit\Runner\Version;
+use PHPUnit\TextUI\DefaultResultPrinter as PHPUnit9ResultPrinter;
+use PHPUnit\TextUI\ResultPrinter as PHPUnit8ResultPrinter;
+
+if (class_exists(Version::class) && (int) Version::series()[0] >= 9) {
+    class IgnoreSkippedPrinter extends PHPUnit9ResultPrinter
+    {
+        protected function printSkipped(TestResult $result): void
+        {
+            //
+        }
+    }
+} else {
+    class IgnoreSkippedPrinter extends PHPUnit8ResultPrinter
+    {
+        protected function printSkipped(TestResult $result): void
+        {
+            //
+        }
+    }
+}

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -362,17 +362,22 @@ class AssertTest extends TestCase
     public function testAssertWhereMatchesValueUsingArrayableWhenSortedDifferently()
     {
         $assert = AssertableJson::fromArray([
-            'bar' => [
-                'baz' => 'foo',
-                'example' => 'value',
+            'data' => [
+                'status' => 200,
+                'user' => [
+                    'id' => 1,
+                    'name' => 'Taylor',
+                ],
             ],
         ]);
 
-        $assert->where('bar', function ($value) {
-            $this->assertInstanceOf(Collection::class, $value);
-
-            return $value->count() === 2;
-        });
+        $assert->where('data', [
+            'user' => [
+                'name' => 'Taylor',
+                'id' => 1,
+            ],
+            'status' => 200,
+        ]);
     }
 
     public function testAssertWhereFailsWhenDoesNotMatchValueUsingArrayable()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -7158,6 +7158,28 @@ class ValidationValidatorTest extends TestCase
         );
     }
 
+    public function testArrayKeysWithDotIntegerMin()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $data = [
+            'foo.bar' => -1,
+        ];
+
+        $rules = [
+            'foo\.bar' => 'integer|min:1',
+        ];
+
+        $expectedResult = [
+            'foo.bar' => [
+                'validation.min.numeric',
+            ],
+        ];
+
+        $validator = new Validator($trans, $data, $rules, [], []);
+        $this->assertEquals($expectedResult, $validator->getMessageBag()->getMessages());
+    }
+
     protected function getTranslator()
     {
         return m::mock(TranslatorContract::class);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2290,6 +2290,24 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => '0.9876'], ['foo' => 'digits_between:1,5']);
         $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '1..2'], ['foo' => 'digits_between:1,10']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '123.456.789'], ['foo' => 'digits_between:1,10']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '...'], ['foo' => 'digits_between:1,10']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '.'], ['foo' => 'digits_between:1,10']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '.2'], ['foo' => 'digits_between:0,10']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '2.'], ['foo' => 'digits_between:1,10']);
+        $this->assertTrue($v->passes());
     }
 
     public function testValidateSize()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2272,6 +2272,30 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => '2e7'], ['foo' => 'Digits:3']);
         $this->assertTrue($v->fails());
 
+        $v = new Validator($trans, ['foo' => '1.2'], ['foo' => 'digits:3']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '0.9876'], ['foo' => 'digits:5']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '1..2'], ['foo' => 'digits:4']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '123.456.789'], ['foo' => 'digits:10']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '...'], ['foo' => 'digits:3']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '.'], ['foo' => 'digits:1']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '.2'], ['foo' => 'digits:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '2.'], ['foo' => 'digits:2']);
+        $this->assertTrue($v->passes());
+
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => '12345'], ['foo' => 'digits_between:1,6']);
         $this->assertTrue($v->passes());

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2284,12 +2284,6 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => '+12.3'], ['foo' => 'digits_between:1,6']);
         $this->assertFalse($v->passes());
-
-        $v = new Validator($trans, ['foo' => '1.2'], ['foo' => 'digits_between:1,10']);
-        $this->assertTrue($v->passes());
-
-        $v = new Validator($trans, ['foo' => '0.9876'], ['foo' => 'digits_between:1,5']);
-        $this->assertTrue($v->fails());
     }
 
     public function testValidateSize()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2272,30 +2272,6 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => '2e7'], ['foo' => 'Digits:3']);
         $this->assertTrue($v->fails());
 
-        $v = new Validator($trans, ['foo' => '1.2'], ['foo' => 'digits:3']);
-        $this->assertTrue($v->passes());
-
-        $v = new Validator($trans, ['foo' => '0.9876'], ['foo' => 'digits:5']);
-        $this->assertTrue($v->fails());
-
-        $v = new Validator($trans, ['foo' => '1..2'], ['foo' => 'digits:4']);
-        $this->assertTrue($v->fails());
-
-        $v = new Validator($trans, ['foo' => '123.456.789'], ['foo' => 'digits:10']);
-        $this->assertTrue($v->fails());
-
-        $v = new Validator($trans, ['foo' => '...'], ['foo' => 'digits:3']);
-        $this->assertTrue($v->fails());
-
-        $v = new Validator($trans, ['foo' => '.'], ['foo' => 'digits:1']);
-        $this->assertTrue($v->fails());
-
-        $v = new Validator($trans, ['foo' => '.2'], ['foo' => 'digits:2']);
-        $this->assertTrue($v->passes());
-
-        $v = new Validator($trans, ['foo' => '2.'], ['foo' => 'digits:2']);
-        $this->assertTrue($v->passes());
-
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => '12345'], ['foo' => 'digits_between:1,6']);
         $this->assertTrue($v->passes());
@@ -2314,24 +2290,6 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => '0.9876'], ['foo' => 'digits_between:1,5']);
         $this->assertTrue($v->fails());
-
-        $v = new Validator($trans, ['foo' => '1..2'], ['foo' => 'digits_between:1,10']);
-        $this->assertTrue($v->fails());
-
-        $v = new Validator($trans, ['foo' => '123.456.789'], ['foo' => 'digits_between:1,10']);
-        $this->assertTrue($v->fails());
-
-        $v = new Validator($trans, ['foo' => '...'], ['foo' => 'digits_between:1,10']);
-        $this->assertTrue($v->fails());
-
-        $v = new Validator($trans, ['foo' => '.'], ['foo' => 'digits_between:1,10']);
-        $this->assertTrue($v->fails());
-
-        $v = new Validator($trans, ['foo' => '.2'], ['foo' => 'digits_between:0,10']);
-        $this->assertTrue($v->passes());
-
-        $v = new Validator($trans, ['foo' => '2.'], ['foo' => 'digits_between:1,10']);
-        $this->assertTrue($v->passes());
     }
 
     public function testValidateSize()


### PR DESCRIPTION
The changes made in this PR will provide the actual pivot model to be passed into the `deleting` & `deleted` events, instead of solely the foreign pivot key & relate pivot key.

### Real life example:
I have a `Company::class` model and a `PaymentMethod::class` model along with a `CompanyPaymentMethod::class` pivot model . The pivot table has an additional boolean column called `is_primary`. In this event I would like to apply some business logic and do certain things when a primary payment method relationship is being destroyed, but I do not have access to the "full" `CompanyPaymentMethod::class` pivot model's attributes as it only come sin with the foreign & primary keys.

The workaround I currently provided in in project was to change my event from `deleted` to `deleting` in order to be able to query the table myself, it is not a good solution as it will cause a `n + 1`, in case a `sync()` or multiple detach is being made.
```
public fucntion deleting(CompanyPaymentMethod $pivot)
{
    $pivot = CompanyPaymentMethod::where([
        'company_id' => $pivot->company_id,
        'payment_method_id' => $pivot->payment_method_id
    ])->first();

    if ($pivot->is_primary) {
        // do something
    }
}
```

🔴  A disadvantage I would see versus the current solution is the fact that this will be making an additional query to retrieve the pivot models to be deleted. But it could save hundreds of queries if there are people applying a workaround like the one I mention above and could prevent saving countless hours in debugging this as all other events pass in the full pivot model as expected.